### PR TITLE
aded fix for grid init size error

### DIFF
--- a/passersby.lua
+++ b/passersby.lua
@@ -1,5 +1,5 @@
 -- Passersby
--- 1.2.1 @markeats
+-- 1.2.2 @markeats
 -- llllllll.co/t/passersby
 --
 -- MIDI or grid controlled West Coast
@@ -553,8 +553,8 @@ end
 
 -- Grid input
 local function grid_key(x, y, z)
-  local note_num = util.clamp(((grid_device.device.rows - 1 - y) * 5) + x + 33, 0, 127)
-  
+  local note_num = util.clamp(((grid_rows - 1 - y) * 5) + x + 33, 0, 127)  
+
   if z == 1 then
     note_on(note_num, 0.8)
     grid_device:led(x, y, 15)
@@ -569,7 +569,7 @@ end
 -- Init
 
 function init()
-  
+
   screen.aa(1)
   
   midi_in_device = midi.connect(1)
@@ -577,6 +577,7 @@ function init()
 
   grid_device = grid.connect(1)
   grid_device.key = grid_key
+  grid_rows = grid_device.rows and grid_device.rows or 8 
   
   -- Add params
   


### PR DESCRIPTION
same as molly_the_polly:

altered the code to have a default value when no grid rows are detectable. also fetching the grid rows from the direct grid object to match midigrid properties.

sorry about the breaking error from last PR. this should fix it.